### PR TITLE
feat: Micro integrations

### DIFF
--- a/methods/flex-micro.js
+++ b/methods/flex-micro.js
@@ -298,10 +298,11 @@ window.SENTRY_INIT_METHODS["flex-micro"] = {
     }
 
     var init_micro_client = function() {
-      const context = {};
-      const integrations = [
-        new Sentry.Integrations.Dedupe()
-      ];
+      const integrationIndex = {};
+
+      if (!integrations?.length) {
+        integrations = [new sdk.Integrations.Dedupe()];
+      }
 
       // Custom integration event processor to define integrations on the event
       let event_processor = (event) => {
@@ -318,6 +319,8 @@ window.SENTRY_INIT_METHODS["flex-micro"] = {
       };
 
       integrations.forEach((integration) => {
+        integrationIndex[integration.name] = integration; 
+
         integration.setupOnce(
           (f) => {          
             event_processor = event_processor
@@ -325,7 +328,7 @@ window.SENTRY_INIT_METHODS["flex-micro"] = {
               : f;
           },
           () => ({
-            getIntegration: (Integration) => context, // TODO: Also Integration._handler?
+            getIntegration: (integration) => integrationIndex[integration.name],
             getClient: () => window.__SENTRY_MICRO__.instances[component_name].client
           })
         )

--- a/methods/lib.js
+++ b/methods/lib.js
@@ -1,0 +1,3 @@
+export function compose_event_processor(...functions) {
+    return (event, hint) => functions.reduceRight((acc, func) => func(acc, hint), event);
+}


### PR DESCRIPTION
Recreate integration stack for each micro-client.

While it works, I'm not entirely sure about the approach, and I'm also not familiar with the limitations around plugins/not using an official hub here. With this browser integrations don't quite work given they access the current hub diffrently. Otherwise, this seems to work for most integrations that also work on node. `Dedupe`, `RewriteFrames` are the main ones I've tested so far.