### PR TITLE
fix: XMLHttpRequest patch not calling onload

### DIFF
--- a/methods/flex-micro.js
+++ b/methods/flex-micro.js
@@ -194,7 +194,7 @@ window.SENTRY_INIT_METHODS["flex-micro"] = {
           var callback_props = ['onload', 'onerror', 'onprogress', 'onreadystatechange'];
           callback_props.forEach(prop  => {
             if (prop in xhr && typeof xhr[prop] === 'function') {
-              patch_prop(xhr, prop, wrap_callback(xhr[prop], patch_func));
+              patch_prop(xhr, prop, function (original) { return wrap_callback(original, patch_func) });
             }
           });
           return original.apply(xhr, args);


### PR DESCRIPTION
Callbacks like `onload` seem to never fire on the patched `XMLHttpRequest` global. I was able to track this down to the original callback getting lost in the shuffle. This patches the original callback to call the original `onload` and other callbacks from XMLHttpRequest.

Apologies for the rapid-fire PRs. I have a running branch that I'm breaking these out of since it seems easier to address each one individually.