### PR TITLE
fix: Guard against errors without a stack

### DIFF
--- a/methods/flex-micro.js
+++ b/methods/flex-micro.js
@@ -95,12 +95,15 @@ window.SENTRY_INIT_METHODS["flex-micro"] = {
     };
 
     var match = function(stack) {
-      let micros = window.__SENTRY_MICRO__.instances;
-      for (const iname in micros) {
-        if (stack.match(micros[iname].matcher)) {
-          return micros[iname];
+      if (stack) {
+        let micros = window.__SENTRY_MICRO__.instances;
+        for (const iname in micros) {
+          if (stack.match(micros[iname].matcher)) {
+            return micros[iname];
+          }
         }
       }
+  
       return null;
     };
 


### PR DESCRIPTION
Ignore errors without a stack, as there is nothing to match against.